### PR TITLE
Adding Min-Width to Accordion Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,3 +157,7 @@ Initial release of the Design System Package
 ## [v1.43.0] - 2022-07-12
 
 - Adding boolean for a white background on the message component
+
+## [v1.44.0] - 2022-07-14
+
+- Adding a min-width to blue portion of the step number of the accordion form component

--- a/src/components/AccordionForm/AccordionForm.js
+++ b/src/components/AccordionForm/AccordionForm.js
@@ -86,7 +86,7 @@ export function AccordionForm(props) {
           {/* Number for the given card */}
           <div className="ds-flex-col ds-pb-12px">
             <div className="cardNumber ds-flex ds-flex-row">
-              <div className="ds-relative ds-rounded-full ds-w-48px ds-h-48px ds-bg-multi-blue-blue60d">
+              <div className="ds-relative ds-rounded-full ds-min-w-[48px] ds-w-48px ds-h-48px ds-bg-multi-blue-blue60d">
                 <p className="ds-leading-48px ds-absolute ds-left-3.5 ds-bottom-0.5 ds-accordion-num">
                   {index + 1}
                 </p>


### PR DESCRIPTION
# [DS-437](https://jira-dev.bdm-dev.dts-stn.com/browse/DS-437) Issue-Accordion Form

**Reminder: Add all changes for this PR to the CHANGELOG.md**

Main Reviewer: @AnthonyA44 

#### Description & Background Context:
with very long titles specially in mobile the blue portion of the background number gets squished 
![image](https://user-images.githubusercontent.com/52539578/179012024-99d52877-2c53-4be5-a27c-90313d5b5acf.png)

#### Where should the reviewer start?
File name: AccordionForm,js 

#### How should this be tested?
- Open the file accordionForm.stories.js change the title: 'Age' for 'a very long title just because' 
- Open storybook and verify the blue portion is no longer squished when on mobile using iPhone 5 view 

#### Are there any breaking changes?
- No