### PR TITLE
DatePicker: use defaultValue instead of value

### DIFF
--- a/src/components/DatePicker/DatePicker.js
+++ b/src/components/DatePicker/DatePicker.js
@@ -50,7 +50,7 @@ export function DatePicker(props) {
           <p className="ds-form-date">{lang === "en" ? "Month" : "Mois"}</p>
           <select
             id="datePickerMonth"
-            value={month}
+            defaultValue={month}
             onChange={onMonthChange}
             className="ds-w-165px ds-py-5px  ds-px-14px ds-date-text ds-border-1.5 ds-border-multi-neutrals-grey85a ds-rounded"
           >
@@ -93,7 +93,7 @@ export function DatePicker(props) {
             <p className="ds-form-date">{lang === "en" ? "Day" : "Jour"}</p>
             <input
               id="datePickerDay"
-              value={day}
+              defaultValue={day}
               type="number"
               min={"1"}
               max={maxDay}
@@ -107,7 +107,7 @@ export function DatePicker(props) {
             <p className="ds-form-date">{lang === "en" ? "Year" : "An"}</p>
             <input
               id="datePickerYear"
-              value={year}
+              defaultValue={year}
               type="number"
               min={minYear}
               max={maxYear}


### PR DESCRIPTION
Fixes: https://github.com/DTS-STN/Service-Canada-Design-System/pull/337

When simply using `value`, we are unable to edit the text box. `value` is for setting the value anyways, which is more than what we want. We just wanted to set the `defaultValue` on page load.