### PR TITLE
fix:inverted language tag for language link

### DIFF
--- a/src/components/Language/Language.js
+++ b/src/components/Language/Language.js
@@ -16,6 +16,7 @@ export function Language(props) {
         abbr={lang === "en" ? "FR" : "EN"}
         locale={props.locale}
         component={props.customLink}
+        lang={lang === "en" ? "fr" : "en"}
       />
     </>
   );


### PR DESCRIPTION
# DS-##(Jira Issue)-A###(component ID)-(component name)

**Reminder: Add all changes for this PR to the CHANGELOG.md**

Main Reviewer: @

#### Description & Background Context: This add a "lang" tag into the Language link in the header. this is helpful for accessibility reasons. The Lang tag was also set to invert ("fr" on English pages, "en" on French pages) so that the tag references the DESTINATION language and not the current language. 

#### Where should the reviewer start?

File name:

#### How should this be tested?

#### Are there any breaking changes?
