### PR TITLE
feat: modify ReactPlayer config to allow crossorigin for subtitle tracks

### DIFF
--- a/src/components/Media/VideoPlayer/Video.js
+++ b/src/components/Media/VideoPlayer/Video.js
@@ -18,7 +18,7 @@ import { Image } from "../../Image/Image";
 import "../styles.css";
 
 export function Video(props) {
-  const { id, videoURL, poster, description, trackProps } = props;
+  const { id, videoURL, poster, description, trackProps, crossOrigin } = props;
   const [state, setState] = React.useState({
     pausePlay: false,
     mute: false,
@@ -180,7 +180,12 @@ export function Video(props) {
               onEnded={handleEnd}
               config={{
                 file: {
-                  attributes: { poster: poster, crossOrigin: "anonymous" },
+                  attributes: {
+                    poster: poster,
+                    crossOrigin: `${
+                      crossOrigin === true ? "anonymous" : false
+                    }`,
+                  },
                   tracks: [
                     {
                       kind: trackProps.kind,
@@ -435,6 +440,10 @@ export function Video(props) {
   );
 }
 
+Video.defaultProps = {
+  crossOrigin: false,
+};
+
 Video.propTypes = {
   /**
    * component id
@@ -468,4 +477,9 @@ Video.propTypes = {
     srcLang: PropTypes.oneOf(["en", "fr"]),
     kind: PropTypes.string,
   }),
+
+  /**
+   * Allow cross-origin requests for subtitle/caption tracks (false by default)
+   */
+  crossOrigin: PropTypes.bool,
 };

--- a/src/components/Media/VideoPlayer/Video.stories.js
+++ b/src/components/Media/VideoPlayer/Video.stories.js
@@ -33,4 +33,5 @@ VideoPlayer.args = {
     src: exampleCaps,
     srcLang: "en",
   },
+  crossOrigin: false,
 };


### PR DESCRIPTION
Allow cross-origin sources for react-player subtitles

#### Description & Background Context:

We're in the process of leveraging the DS video player component and are working on implementing our subtitles and in testing found that the underlying react-player needs to be configured to allow for cross-origin sources for the subtitles tracks if you want to get your subs from an API. Luckily this is as simple as adding a single field to the attributes object in the config.file. Of course each project's CORS configuration is something to be aware of as well but this opens up the component to more flexibility of use with APIs that some like ourselves may use to provide the subtitle tracks.

You can see from these examples that getting subs cross-origin involves this configuration + a proper CORS config:

https://github.com/CookPete/react-player/issues/561

https://stackoverflow.com/questions/67161486/react-player-subtitles-are-not-showing

#### Where should the reviewer start?

File name: Video.js

#### How should this be tested?

For a simple test, check out this jsfiddle:
 https://jsfiddle.net/t16c2egv/2/

Without the changes in this PR, use a [remote URL](https://raw.githubusercontent.com/vidstack/media-files/main/subs/english.vtt) for the .vtt file in the Video.stories.js, go to the storybook, and see in the console an error similar to this:

<img width="576" alt="Screenshot 2023-06-06 at 12 15 51 PM" src="https://github.com/DTS-STN/Service-Canada-Design-System/assets/31868510/80144469-8301-4bdb-bfa8-13f6a34f14bd">

With the changes in this PR, use a [remote URL](https://raw.githubusercontent.com/vidstack/media-files/main/subs/english.vtt) for the .vtt file in the Video.stories.js, go to the storybook, and see in the console either no error, or a CORS error.

#### Are there any breaking changes?

No
